### PR TITLE
Avoid taurus

### DIFF
--- a/sardana_ni660x/ctrl/Ni660XCTCtrl.py
+++ b/sardana_ni660x/ctrl/Ni660XCTCtrl.py
@@ -217,7 +217,8 @@ class Ni660XCTCtrl(object):
             for card_dev_name in cards.keys():
                 card_dev = taurus.Device(card_dev_name)
                 card_dev.removeListener(self.cardEventReceived)
-
+                del self.cards[card_dev]
+                del self.card_configured[card_dev]
 
     def GetAxisExtraPar(self, axis, name):
         self._log.debug("GetAxisExtraPar(%d, %s) entering..." % (axis, name))

--- a/sardana_ni660x/ctrl/Ni660XCTCtrl.py
+++ b/sardana_ni660x/ctrl/Ni660XCTCtrl.py
@@ -229,14 +229,12 @@ class Ni660XCTCtrl(object):
             v = self.channelDevNamesList[axis-1]
         elif name in self.direct_attributes:
             channel = self.channels[axis]
-            attr = channel.getAttribute(name)
-            v = attr.read().value
+            v = channel.read_attribute(name).value
         else:
             v = self.attributes[axis][name]
             if name in self.cached_attributes and v is None:
                 channel = self.channels[axis]
-                attr = channel.getAttribute(name)
-                v = attr.read().value
+                v = channel.read_attribute(name).value
         return v
 
     def SetAxisExtraPar(self, axis, name, value):
@@ -249,8 +247,7 @@ class Ni660XCTCtrl(object):
             channel = self.channels[axis]
             if channel.State() != PyTango.DevState.STANDBY:
                 channel.Stop()
-            attr = self.channels[axis].getAttribute(name)
-            attr.write(value)
+            self.channels[axis].write_attribute(name, value)
         else:
             self.attributes[axis][name] = value
             if name in self.cached_attributes:
@@ -449,7 +446,7 @@ class Ni660XCTCtrl(object):
             if self.delay_counter[axis] == 0:
                 try:
                     channel = self.channels[axis]
-                    data = channel.getAttribute(self.BUFFER_ATTR).read().rvalue.magnitude
+                    data = channel.read_attribute(self.BUFFER_ATTR).value
                     if data is None:
                         data = numpy.array([0])
                 except Exception as e:
@@ -483,7 +480,7 @@ class Ni660XCTCtrl(object):
             if self.delay_counter[axis] == 0:
                 try:
                     channel = self.channels[axis]
-                    data = channel.getAttribute(self.BUFFER_ATTR).read().rvalue.magnitude
+                    data = channel.read_attribute(self.BUFFER_ATTR).value
                     if data is None:
                         data = numpy.array([])
                 except Exception as e:

--- a/sardana_ni660x/ctrl/Ni660XCTCtrl.py
+++ b/sardana_ni660x/ctrl/Ni660XCTCtrl.py
@@ -257,7 +257,7 @@ class Ni660XCTCtrl(object):
                 self.ch_configured[axis] = False
 
     def StateOneSingle(self, axis):
-        state = self.channels[axis].stateObj.read().rvalue
+        state = self.channels[axis].stateObj.read(cache=False).rvalue
 
         # Force State ON for Timer
         if axis == 1:
@@ -282,7 +282,7 @@ class Ni660XCTCtrl(object):
 
     def StateOneMultiple(self, axis):
         if axis != 1:
-            state = self.channels[axis].stateObj.read().rvalue
+            state = self.channels[axis].stateObj.read(cache=False).rvalue
             # RUNNING state translates directly to MOVING
             if state == PyTango.DevState.RUNNING:
                 state = State.Moving

--- a/sardana_ni660x/ctrl/Ni660XCTCtrl.py
+++ b/sardana_ni660x/ctrl/Ni660XCTCtrl.py
@@ -254,7 +254,7 @@ class Ni660XCTCtrl(object):
                 self.ch_configured[axis] = False
 
     def StateOneSingle(self, axis):
-        state = self.channels[axis].stateObj.read(cache=False).rvalue
+        state = self.channels[axis].State()
 
         # Force State ON for Timer
         if axis == 1:
@@ -279,7 +279,7 @@ class Ni660XCTCtrl(object):
 
     def StateOneMultiple(self, axis):
         if axis != 1:
-            state = self.channels[axis].stateObj.read(cache=False).rvalue
+            state = self.channels[axis].State()
             # RUNNING state translates directly to MOVING
             if state == PyTango.DevState.RUNNING:
                 state = State.Moving


### PR DESCRIPTION
Avoid using taurus to read/write NI tango server attributes.

Using taurus `getAttribute()` has a consequence of making a subscription to config events and an unsubscription when the TaurusAttribute is discarded. The calls are very frequent so this introduces a lot of overhead.

This PR fixes this by using direct read/write attribute tango calls.

This PR depends on #1 being accepted