### PR TITLE
New axis attributes dutycycle idlestate

### DIFF
--- a/sardana_ni660x/ctrl/Ni660XCTCtrl.py
+++ b/sardana_ni660x/ctrl/Ni660XCTCtrl.py
@@ -3,7 +3,6 @@ import numpy
 
 import PyTango
 import taurus
-from taurus.core.util import SafeEvaluator
 
 from sardana import State
 from sardana.pool import AcqSynch
@@ -11,6 +10,8 @@ from sardana.pool.controller import (CounterTimerController, Memorize,
                                      Memorized, NotMemorized, Type, Access,
                                      DataAccess, Description, DefaultValue)
 from sardana.sardanavalue import SardanaValue
+
+from sardana_ni660x.utils import CONNECTTERMS_DOC, getPFINameFromFriendlyWords, ConnectTerms
 
 ReadWrite = DataAccess.ReadWrite
 ReadOnly = DataAccess.ReadOnly
@@ -21,42 +22,6 @@ CHANNELDEVNAMES_DOC = ('Comma separated Ni660XCounter Tango device names.',
                        ' Subsequent channels (configured with "input"'
                        ' application type e.g. CICountEdgesChan) are used'
                        ' as counters.')
-
-CONNECTTERMS_DOC = ('String with dictionary form. Keys are Ni660X Tango' 
-                    ' device names. Each value is a list of tuples.'
-                    ' Each tuple has: (source termninal, destination terminal'
-                    ' , polarity configuration)')
-
-NI6602_PFI = {
-    "ctr0": {"src": "PFI39", "gate": "PFI38", "out": "PFI36", "aux": "PFI37"},
-    "ctr1": {"src": "PFI35", "gate": "PFI34", "out": "PFI32", "aux": "PFI33"},
-    "ctr2": {"src": "PFI31", "gate": "PFI30", "out": "PFI28", "aux": "PFI29"},
-    "ctr3": {"src": "PFI27", "gate": "PFI26", "out": "PFI24", "aux": "PFI25"},
-    "ctr4": {"src": "PFI23", "gate": "PFI22", "out": "PFI20", "aux": "PFI21"},
-    "ctr5": {"src": "PFI19", "gate": "PFI18", "out": "PFI16", "aux": "PFI17"},
-    "ctr6": {"src": "PFI15", "gate": "PFI14", "out": "PFI12", "aux": "PFI13"},
-    "ctr7": {"src": "PFI11", "gate": "PFI10", "out": "PFI8",  "aux": "PFI9"}}
-
-def getPFIName(counterName, signal):
-    """ Method to get the PFI signal name for each counter, e.g.:/Dev1/ctr1 """
-    counter = counterName[-4:].lower()
-    pfi = NI6602_PFI[counter][signal.lower()]
-    return counterName[:-4] + pfi
-
-def getPFINameFromFriendlyWords(counter):
-    """
-    Method to check/extract the PFI from a counter name
-    Can be used with /dev1/PFI34 format or /dev1/ctr1/gate
-    """
-    # Convert from friendly words
-    if 'rtsi'in counter.lower():
-        pass
-    elif not 'pfi' in counter.lower():
-        term = counter.rsplit('/',1)
-        ctr = term[0]
-        signal = term[1]
-        counter = getPFIName(ctr, signal)
-    return counter
 
 class Ni660XCTCtrl(object):
     """This class is the Ni600X counter Sardana CounterTimerController.
@@ -130,19 +95,10 @@ class Ni660XCTCtrl(object):
         self._repetitions = 0
         self.state = State.Unknown
         self.status = ""
-        self.cards = {}
-        self.card_configured = {}
         self.ch_configured = {}
-        self.sev = SafeEvaluator()
         self._latency_time = self.latencyTime
         self.current_ch_configured = 0
-        cards = self.sev.eval(self.connectTerms)
-        for card_dev_name in cards.keys():
-            value = cards[card_dev_name]
-            card_dev = taurus.Device(card_dev_name)
-            self.cards[card_dev] = value
-            self.card_configured[card_dev] = False
-
+        self.connect_terms_util = ConnectTerms(self.connectTerms)
 
     def AddDevice(self, axis):
         channel_name = self.channelDevNamesList[axis-1]
@@ -183,11 +139,7 @@ class Ni660XCTCtrl(object):
             self.ch_configured.pop(axis)
         self.channels.pop(axis)
         if len(self.channels) == 0:
-            cards = self.sev.eval(self.connectTerms)
-            for card_dev_name in cards.keys():
-                card_dev = taurus.Device(card_dev_name)
-                del self.cards[card_dev]
-                del self.card_configured[card_dev]
+            self.connect_terms_util.delete_cards()
 
     def GetAxisExtraPar(self, axis, name):
         self._log.debug("GetAxisExtraPar(%d, %s) entering..." % (axis, name))
@@ -296,18 +248,8 @@ class Ni660XCTCtrl(object):
         self._log.debug("PreStartAll(): Entering...")
         # Reset all the channel's Indexe
         self.index = {}
-        for card_dev in self.card_configured.keys():
-            for device_tuple in self.cards[card_dev]:
-                src_terminal = device_tuple[0]
-                #Check if is defined as a friendly words
-                src_terminal = getPFINameFromFriendlyWords(src_terminal)
-                dest_terminal = device_tuple[1]
-                dest_terminal = getPFINameFromFriendlyWords(dest_terminal)
-                polarity = device_tuple[2]
-                card_dev.ConnectTerms([src_terminal,
-                                       dest_terminal,
-                                       polarity])
-            self.card_configured[card_dev] = True
+        # Apply connect terms
+        self.connect_terms_util.apply_connect_terms()
         self._log.debug("PreStartAll(): Leaving...")
         return True
 

--- a/sardana_ni660x/ctrl/Ni660XPulseWidthCTCtrl.py
+++ b/sardana_ni660x/ctrl/Ni660XPulseWidthCTCtrl.py
@@ -1,5 +1,9 @@
-from sardana.pool.controller import CounterTimerController
-from sardana_ni660x.ctrl.Ni660XCTCtrl import *
+from sardana import DataAccess
+from sardana.pool.controller import (CounterTimerController, Memorize,
+                                     Memorized, Type, Access)
+
+from sardana_ni660x.ctrl.Ni660XCTCtrl import Ni660XCTCtrl
+from sardana_ni660x.utils import getPFIName
 
 
 # The order of inheritance is important. The CounterTimerController
@@ -19,7 +23,7 @@ class Ni660XPulseWidthCTCtrl(Ni660XCTCtrl, CounterTimerController):
     axis_attributes.update({
         "inputterminal": {
             Type: str,
-            Access: ReadWrite,
+            Access: DataAccess.ReadWrite,
             Memorize: Memorized
         },
     })

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -78,7 +78,18 @@ class Ni660XTriggerGateController(TriggerGateController):
             Access: ReadWrite,
             Memorize: Memorized,
             DefaultValue: 100
-        }
+        },
+        'startTriggerSource': {
+            Type: str,
+            Access: ReadWrite,
+            Memorize: Memorized,
+        },
+        'triggerSourceType': {
+            Type: str,
+            Access: ReadWrite,
+            Memorize: Memorized,
+            DefaultValue: "DigEdge"
+        },
     }
 
     # relation between state and status  
@@ -101,6 +112,8 @@ class Ni660XTriggerGateController(TriggerGateController):
         self.extraInitialDelayTime = 0
         self.idle_states = {}
         self.duty_cycles = {}
+        self.start_trigger_source = {}
+        self.trigger_source_type = {}
 
     def AddDevice(self, axis):
         """
@@ -173,6 +186,13 @@ class Ni660XTriggerGateController(TriggerGateController):
         if self.slave:
             startTriggerSource = self.startTriggerSource
             startTriggerType = self.startTriggerType
+            if self.start_trigger_source.get(axis) is not None and \
+                self.start_trigger_source.get(axis) != "":
+                startTriggerSource = self.start_trigger_source[axis]
+                startTriggerType = self.trigger_source_type[axis]
+                msg = "startTriggerSource is set for axis {}. Using axis attribute {}" \
+                      "instead of controller property {}.".format(axis, startTriggerSource, self.startTriggerSource)
+                self.warning(msg)
             # If the trigger is manage by external trigger the delay time should be 0
             delay = 0        
             # The trigger should be retriggerable by external trigger?
@@ -249,6 +269,12 @@ class Ni660XTriggerGateController(TriggerGateController):
             v = self.idle_states[axis].value
         elif name == 'dutyCycle':
             v = self.duty_cycles[axis]
+        elif name == 'startTriggerSource':
+            v = self.start_trigger_source.get(axis)
+            if v is None:
+                v = ""
+        elif name == 'triggerSourceType':
+            v = self.trigger_source_type[axis]
         return v
 
     def SetAxisExtraPar(self, axis, name, value):
@@ -274,3 +300,7 @@ class Ni660XTriggerGateController(TriggerGateController):
                         "and 100 (included): (0,100]".format(value)
             assert 0 < value <=100, error_msg
             self.duty_cycles[axis] = value
+        elif name == 'startTriggerSource':
+            self.start_trigger_source[axis] = value
+        elif name == 'triggerSourceType':
+            self.trigger_source_type[axis] = value

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -283,15 +283,15 @@ class Ni660XTriggerGateController(TriggerGateController):
             v = self.retriggerable
         elif name == 'extrainitialdelaytime':
             v = self.extraInitialDelayTime
-        elif name == 'idleState':
+        elif name == 'idlestate':
             v = self.idle_states[axis].value
-        elif name == 'dutyCycle':
+        elif name == 'dutycycle':
             v = self.duty_cycles[axis]
-        elif name == 'startTriggerSource':
+        elif name == 'starttriggersource':
             v = self.start_trigger_source.get(axis)
             if v is None:
                 v = ""
-        elif name == 'triggerSourceType':
+        elif name == 'triggersourcetype':
             v = self.trigger_source_type[axis]
         return v
 
@@ -308,17 +308,17 @@ class Ni660XTriggerGateController(TriggerGateController):
             self.channels[axis].write_attribute('retriggerable', value)
         elif name == 'extrainitialdelaytime':
             self.extraInitialDelayTime = value
-        elif name == 'idleState':
+        elif name == 'idlestate':
             idle_states = [state.value for state in IdleState]
             error_msg = "String {} must be either in {}".format(value, idle_states)
             assert value in idle_states, error_msg
             self.idle_states[axis] = IdleState(value)
-        elif name == 'dutyCycle':
+        elif name == 'dutycycle':
             error_msg = "Value {} must be a percentage between 0 (not included) " + \
                         "and 100 (included): (0,100]".format(value)
             assert 0 < value <=100, error_msg
             self.duty_cycles[axis] = value
-        elif name == 'startTriggerSource':
+        elif name == 'starttriggersource':
             self.start_trigger_source[axis] = value
-        elif name == 'triggerSourceType':
+        elif name == 'triggersourcetype':
             self.trigger_source_type[axis] = value

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -66,7 +66,8 @@ class Ni660XTriggerGateController(TriggerGateController):
         "retriggerable": {
             Type: bool,
             Access: ReadWrite,            
-            Memorize: Memorized
+            Memorize: Memorized,
+            DefaultValue: False
         },
         "extraInitialDelayTime": {
             Type: float,
@@ -115,7 +116,7 @@ class Ni660XTriggerGateController(TriggerGateController):
         self.channel_names = self.channelDevNames.split(",")
         self.channels = {}
         self.slave = {}
-        self.retriggerable = False
+        self.retriggerable = {}
         self.extraInitialDelayTime = 0
         self.idle_states = {}
         self.duty_cycles = {}
@@ -208,7 +209,7 @@ class Ni660XTriggerGateController(TriggerGateController):
             # If the trigger is manage by external trigger the delay time should be 0
             delay = 0        
             # The trigger should be retriggerable by external trigger?
-            if self.retriggerable:
+            if self.retriggerable[axis]:
                 channel.write_attribute('retriggerable',1)
                 timing_type = 'OnDemand'
                 # Set the LowTime to the minimum value. It is needed because
@@ -305,7 +306,7 @@ class Ni660XTriggerGateController(TriggerGateController):
         elif name == 'retriggerable':
             if self._getState(axis) is State.On:
                 self.channels[axis].stop()
-            self.retriggerable = value
+            self.retriggerable[axis] = value
             self.channels[axis].write_attribute('retriggerable', value)
         elif name == 'extrainitialdelaytime':
             self.extraInitialDelayTime = value

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -3,12 +3,12 @@ from sardana import State
 from sardana.pool.pooldefs import SynchDomain, SynchParam
 from sardana.pool.controller import (TriggerGateController, Type, Description,
                                      DefaultValue, Access, DataAccess, Memorize, 
-                                     Memorized, NotMemorized)
+                                     Memorized)
 
 from sardana.tango.core.util import from_tango_state_to_state
 
 from sardana_ni660x.utils import IdleState
-from sardana_ni660x.utils import CONNECTTERMS_DOC, getPFINameFromFriendlyWords, ConnectTerms
+from sardana_ni660x.utils import CONNECTTERMS_DOC, ConnectTerms
 
 ReadWrite = DataAccess.ReadWrite
 ReadOnly = DataAccess.ReadOnly

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -61,7 +61,7 @@ class Ni660XTriggerGateController(TriggerGateController):
             Type: bool,
             Access: ReadWrite,
             Memorize: Memorized,
-            Default: False
+            DefaultValue: False
         },
         "retriggerable": {
             Type: bool,
@@ -281,8 +281,8 @@ class Ni660XTriggerGateController(TriggerGateController):
         if name == "slave":
             v = self.slave[axis]
         elif name == 'retriggerable':
-            self.rettrigerable =  self.channels[axis].read_attribute('retriggerable').value
-            v = self.retriggerable
+            self.retriggerable[axis] = self.channels[axis].read_attribute('retriggerable').value
+            v = self.retriggerable[axis]
         elif name == 'extrainitialdelaytime':
             v = self.extraInitialDelayTime[axis]
         elif name == 'idlestate':

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -133,20 +133,20 @@ class Ni660XTriggerGateController(TriggerGateController):
 
     def AddDevice(self, axis):
         """
-        Add axis to the controller, basically creates a taurus device of
+        Add axis to the controller, basically creates a tango device of
         the corresponding channel.
         """
         channel_name = self.channel_names[axis - 1]
         try:
             self.channels[axis] = PyTango.DeviceProxy(channel_name)
         except Exception as e:
-            msg = 'Could not create taurus device: %s, details: %s' %\
+            msg = 'Could not create tango device: %s, details: %s' %\
                   (channel_name, e)
             self._log.debug(msg)
 
     def DeleteDevice(self, axis):
         """
-        Remove axis from the controller, basically forgets about the taurus
+        Remove axis from the controller, basically forgets about the tango
         device of the corresponding channel.
         """
         self.channels.pop(axis)

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -117,7 +117,7 @@ class Ni660XTriggerGateController(TriggerGateController):
         self.channels = {}
         self.slave = {}
         self.retriggerable = {}
-        self.extraInitialDelayTime = 0
+        self.extraInitialDelayTime = {}
         self.idle_states = {}
         self.duty_cycles = {}
         self.start_trigger_source = {}
@@ -224,8 +224,8 @@ class Ni660XTriggerGateController(TriggerGateController):
                                 
         channel.write_attribute("StartTriggerSource", startTriggerSource)
         channel.write_attribute("StartTriggerType", startTriggerType)
-        delay = delay + self.extraInitialDelayTime
-        self.extraInitialDelayTime = 0
+        delay = delay + self.extraInitialDelayTime[axis]
+        self.extraInitialDelayTime[axis] = 0
         channel.write_attribute("InitialDelayTime", delay)
         channel.write_attribute('SampleTimingType', timing_type)
         
@@ -284,7 +284,7 @@ class Ni660XTriggerGateController(TriggerGateController):
             self.rettrigerable =  self.channels[axis].read_attribute('retriggerable').value
             v = self.retriggerable
         elif name == 'extrainitialdelaytime':
-            v = self.extraInitialDelayTime
+            v = self.extraInitialDelayTime[axis]
         elif name == 'idlestate':
             v = self.idle_states[axis].value
         elif name == 'dutycycle':
@@ -309,7 +309,7 @@ class Ni660XTriggerGateController(TriggerGateController):
             self.retriggerable[axis] = value
             self.channels[axis].write_attribute('retriggerable', value)
         elif name == 'extrainitialdelaytime':
-            self.extraInitialDelayTime = value
+            self.extraInitialDelayTime[axis] = value
         elif name == 'idlestate':
             idle_states = [state.value for state in IdleState]
             error_msg = "String {} must be either in {}".format(value, idle_states)

--- a/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
+++ b/sardana_ni660x/ctrl/Ni660XTriggerGateController.py
@@ -98,6 +98,12 @@ class Ni660XTriggerGateController(TriggerGateController):
             Memorize: Memorized,
             DefaultValue: "DigEdge"
         },
+        'ignoreSlaveDelay': {
+            Type: bool,
+            Access: ReadWrite,
+            Memorize: Memorized,
+            DefaultValue: True
+        }
     }
 
     # relation between state and status  
@@ -122,6 +128,7 @@ class Ni660XTriggerGateController(TriggerGateController):
         self.duty_cycles = {}
         self.start_trigger_source = {}
         self.trigger_source_type = {}
+        self.ignore_slave_delay = {}
         self.connect_terms_util = ConnectTerms(self.connectTerms)
 
     def AddDevice(self, axis):
@@ -206,8 +213,9 @@ class Ni660XTriggerGateController(TriggerGateController):
                 msg = "startTriggerSource is set for axis {}. Using axis attribute {}" \
                       "instead of controller property {}.".format(axis, startTriggerSource, self.startTriggerSource)
                 self._log.warning(msg)
-            # If the trigger is manage by external trigger the delay time should be 0
-            delay = 0        
+            if self.ignore_slave_delay[axis]:
+                # If the trigger is managed by external trigger the delay time (usually acceleration time) may not be desired.
+                delay = 0        
             # The trigger should be retriggerable by external trigger?
             if self.retriggerable[axis]:
                 channel.write_attribute('retriggerable',1)
@@ -295,6 +303,8 @@ class Ni660XTriggerGateController(TriggerGateController):
                 v = ""
         elif name == 'triggersourcetype':
             v = self.trigger_source_type[axis]
+        elif name == 'ignoreslavedelay':
+            v = self.ignore_slave_delay[axis]
         return v
 
     def SetAxisExtraPar(self, axis, name, value):
@@ -324,3 +334,5 @@ class Ni660XTriggerGateController(TriggerGateController):
             self.start_trigger_source[axis] = value
         elif name == 'triggersourcetype':
             self.trigger_source_type[axis] = value
+        elif name == 'ignoreslavedelay':
+            self.ignore_slave_delay[axis] = value

--- a/sardana_ni660x/utils.py
+++ b/sardana_ni660x/utils.py
@@ -1,6 +1,80 @@
 from enum import Enum
 
+import taurus
+from taurus.core.util import SafeEvaluator
+
 class IdleState(Enum):
     LOW = "Low"
     HIGH = "High"
     NOT_SET = "NotSet"
+
+CONNECTTERMS_DOC = ('String with dictionary form. Keys are Ni660X Tango' 
+                    ' device names. Each value is a list of tuples.'
+                    ' Each tuple has: (source termninal, destination terminal'
+                    ' , polarity configuration)')
+
+NI6602_PFI = {
+    "ctr0": {"src": "PFI39", "gate": "PFI38", "out": "PFI36", "aux": "PFI37"},
+    "ctr1": {"src": "PFI35", "gate": "PFI34", "out": "PFI32", "aux": "PFI33"},
+    "ctr2": {"src": "PFI31", "gate": "PFI30", "out": "PFI28", "aux": "PFI29"},
+    "ctr3": {"src": "PFI27", "gate": "PFI26", "out": "PFI24", "aux": "PFI25"},
+    "ctr4": {"src": "PFI23", "gate": "PFI22", "out": "PFI20", "aux": "PFI21"},
+    "ctr5": {"src": "PFI19", "gate": "PFI18", "out": "PFI16", "aux": "PFI17"},
+    "ctr6": {"src": "PFI15", "gate": "PFI14", "out": "PFI12", "aux": "PFI13"},
+    "ctr7": {"src": "PFI11", "gate": "PFI10", "out": "PFI8",  "aux": "PFI9"}}
+
+def getPFIName(counterName, signal):
+    """ Method to get the PFI signal name for each counter, e.g.:/Dev1/ctr1 """
+    counter = counterName[-4:].lower()
+    pfi = NI6602_PFI[counter][signal.lower()]
+    return counterName[:-4] + pfi
+
+def getPFINameFromFriendlyWords(counter):
+    """
+    Method to check/extract the PFI from a counter name
+    Can be used with /dev1/PFI34 format or /dev1/ctr1/gate
+    """
+    # Convert from friendly words
+    if 'rtsi'in counter.lower():
+        pass
+    elif not 'pfi' in counter.lower():
+        term = counter.rsplit('/',1)
+        ctr = term[0]
+        signal = term[1]
+        counter = getPFIName(ctr, signal)
+    return counter
+
+class ConnectTerms:
+    def __init__(self, connect_terms):
+        self.connectTerms = connect_terms
+        self.sev = SafeEvaluator()
+        self.cards = {}
+        self.card_configured = {}
+        cards = self.sev.eval(self.connectTerms)
+        for card_dev_name in cards.keys():
+            value = cards[card_dev_name]
+            card_dev = taurus.Device(card_dev_name)
+            self.cards[card_dev] = value
+            self.card_configured[card_dev] = False
+
+    def apply_connect_terms(self):
+        for card_dev in self.card_configured.keys():
+            for device_tuple in self.cards[card_dev]:
+                src_terminal = device_tuple[0]
+                #Check if is defined as a friendly words
+                src_terminal = getPFINameFromFriendlyWords(src_terminal)
+                dest_terminal = device_tuple[1]
+                dest_terminal = getPFINameFromFriendlyWords(dest_terminal)
+                polarity = device_tuple[2]
+                card_dev.ConnectTerms([src_terminal,
+                                       dest_terminal,
+                                       polarity])
+            self.card_configured[card_dev] = True
+
+    def delete_cards(self):
+        cards = self.sev.eval(self.connectTerms)
+        for card_dev_name in cards.keys():
+            card_dev = taurus.Device(card_dev_name)
+            del self.cards[card_dev]
+            del self.card_configured[card_dev]
+

--- a/sardana_ni660x/utils.py
+++ b/sardana_ni660x/utils.py
@@ -71,7 +71,7 @@ class ConnectTerms:
             self.card_configured[card_dev] = True
 
     def delete_cards(self):
-        cards = self.sev.eval(self.connectTerms)
+        cards = eval(self.connectTerms)
         for card_dev_name in cards.keys():
             card_dev = tango.DeviceProxy(card_dev_name)
             del self.cards[card_dev]

--- a/sardana_ni660x/utils.py
+++ b/sardana_ni660x/utils.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
-import taurus
-from taurus.core.util import SafeEvaluator
+import tango
 
 class IdleState(Enum):
     LOW = "Low"
@@ -48,13 +47,12 @@ def getPFINameFromFriendlyWords(counter):
 class ConnectTerms:
     def __init__(self, connect_terms):
         self.connectTerms = connect_terms
-        self.sev = SafeEvaluator()
         self.cards = {}
         self.card_configured = {}
-        cards = self.sev.eval(self.connectTerms)
+        cards = eval(self.connectTerms)
         for card_dev_name in cards.keys():
             value = cards[card_dev_name]
-            card_dev = taurus.Device(card_dev_name)
+            card_dev = tango.DeviceProxy(card_dev_name)
             self.cards[card_dev] = value
             self.card_configured[card_dev] = False
 
@@ -75,7 +73,7 @@ class ConnectTerms:
     def delete_cards(self):
         cards = self.sev.eval(self.connectTerms)
         for card_dev_name in cards.keys():
-            card_dev = taurus.Device(card_dev_name)
+            card_dev = tango.DeviceProxy(card_dev_name)
             del self.cards[card_dev]
             del self.card_configured[card_dev]
 

--- a/sardana_ni660x/utils.py
+++ b/sardana_ni660x/utils.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class IdleState(Enum):
+    LOW = "Low"
+    HIGH = "High"
+    NOT_SET = "NotSet"

--- a/sardana_ni660x/utils.py
+++ b/sardana_ni660x/utils.py
@@ -11,7 +11,8 @@ class IdleState(Enum):
 CONNECTTERMS_DOC = ('String with dictionary form. Keys are Ni660X Tango' 
                     ' device names. Each value is a list of tuples.'
                     ' Each tuple has: (source termninal, destination terminal'
-                    ' , polarity configuration)')
+                    ' , polarity configuration). IMPORTANT: declare this property'
+                    ' only in one controller (TriggerGate or CounterTimer controller).')
 
 NI6602_PFI = {
     "ctr0": {"src": "PFI39", "gate": "PFI38", "out": "PFI36", "aux": "PFI37"},


### PR DESCRIPTION
Add two new attributes:
- IdleState: Indicates wether the signal of the pulse will be inverted. Can be 'Low' (default) or 'High'.
- dutyCyle: a percentage between 0 (not included) and 100 (included) which indicates the actual time the signal will be in 'active'. Very helpful if the hardware operates in TRIGGER mode and doesn't need the duration of the pulse to be equal than the integration time. We can customize the signal a little bit for other needs.